### PR TITLE
':authority' pseudo-header field support

### DIFF
--- a/lib/net-http2/request.rb
+++ b/lib/net-http2/request.rb
@@ -24,7 +24,7 @@ module NetHttp2
         ':path'   => @path,
       })
 
-      @headers.merge!('host' => @uri.host) unless @headers['host']
+      @headers.merge!(':authority' => "#{@uri.host}:#{@uri.port}") unless @headers[':authority']
 
       if @body
         @headers.merge!('content-length' => @body.bytesize.to_s)

--- a/spec/api/sending_async_requests_spec.rb
+++ b/spec/api/sending_async_requests_spec.rb
@@ -55,7 +55,7 @@ describe "Sending async requests" do
     expect(incoming_request.headers[":scheme"]).to eq "http"
     expect(incoming_request.headers[":method"]).to eq "GET"
     expect(incoming_request.headers[":path"]).to eq "/path"
-    expect(incoming_request.headers["host"]).to eq "localhost"
+    expect(incoming_request.headers[":authority"]).to eq "localhost:#{port}"
     expect(incoming_request.headers["x-custom-header"]).to eq "custom"
   end
 
@@ -104,7 +104,7 @@ describe "Sending async requests" do
     expect(incoming_request.headers[":scheme"]).to eq "http"
     expect(incoming_request.headers[":method"]).to eq "GET"
     expect(incoming_request.headers[":path"]).to eq "/path"
-    expect(incoming_request.headers["host"]).to eq "localhost"
+    expect(incoming_request.headers[":authority"]).to eq "localhost:#{port}"
     expect(incoming_request.headers["x-custom-header"]).to eq "custom"
     expect(incoming_request.body).to eq "request body"
   end

--- a/spec/api/sending_sync_requests_spec.rb
+++ b/spec/api/sending_sync_requests_spec.rb
@@ -34,7 +34,7 @@ describe "Sending sync requests" do
     expect(request.headers[":scheme"]).to eq "http"
     expect(request.headers[":method"]).to eq "GET"
     expect(request.headers[":path"]).to eq "/path"
-    expect(request.headers["host"]).to eq "localhost"
+    expect(request.headers[":authority"]).to eq "localhost:#{port}"
     expect(request.headers["x-custom-header"]).to eq "custom"
   end
 
@@ -61,7 +61,7 @@ describe "Sending sync requests" do
     expect(request.headers[":scheme"]).to eq "http"
     expect(request.headers[":method"]).to eq "POST"
     expect(request.headers[":path"]).to eq "/path"
-    expect(request.headers["host"]).to eq "localhost"
+    expect(request.headers[":authority"]).to eq "localhost:#{port}"
     expect(request.headers["x-custom-header"]).to eq "custom"
 
     expect(request.body).to eq "body"

--- a/spec/api/ssl_requests_spec.rb
+++ b/spec/api/ssl_requests_spec.rb
@@ -31,7 +31,7 @@ describe "SSL Requests" do
     expect(request.headers[":scheme"]).to eq "https"
     expect(request.headers[":method"]).to eq "GET"
     expect(request.headers[":path"]).to eq "/path"
-    expect(request.headers["host"]).to eq "localhost"
+    expect(request.headers[":authority"]).to eq "localhost:#{port}"
   end
 
   it "sends SSL GET requests and receives big bodies" do
@@ -56,7 +56,7 @@ describe "SSL Requests" do
     expect(request.headers[":scheme"]).to eq "https"
     expect(request.headers[":method"]).to eq "GET"
     expect(request.headers[":path"]).to eq "/path"
-    expect(request.headers["host"]).to eq "localhost"
+    expect(request.headers[":authority"]).to eq "localhost:#{port}"
   end
 
   it "sends SSL POST requests with big bodies" do

--- a/spec/http2-client/request_spec.rb
+++ b/spec/http2-client/request_spec.rb
@@ -38,7 +38,7 @@ describe NetHttp2::Request do
             ':scheme'        => 'http',
             ':method'        => 'POST',
             ':path'          => '/path',
-            'host'           => 'localhost',
+            ':authority'     => 'localhost:80',
             'content-length' => '12'
           }
         ) }
@@ -50,7 +50,7 @@ describe NetHttp2::Request do
             ':scheme'        => 'https',
             ':method'        => 'OTHER',
             ':path'          => '/another',
-            'host'           => 'rob.local',
+            ':authority'     => 'rob.local:80',
             'x-custom'       => 'custom',
             'content-length' => '999'
           }
@@ -61,7 +61,7 @@ describe NetHttp2::Request do
             ':scheme'        => 'http',
             ':method'        => 'POST',
             ':path'          => '/path',
-            'host'           => 'rob.local',
+            ':authority'     => 'rob.local:80',
             'x-custom'       => 'custom',
             'content-length' => '12'
           }
@@ -78,10 +78,10 @@ describe NetHttp2::Request do
 
         it { is_expected.to eq(
           {
-            ':scheme' => 'http',
-            ':method' => 'GET',
-            ':path'   => '/path',
-            'host'    => 'localhost'
+            ':scheme'    => 'http',
+            ':method'    => 'GET',
+            ':path'      => '/path',
+            ':authority' => 'localhost:80'
           }
         ) }
       end
@@ -92,7 +92,7 @@ describe NetHttp2::Request do
             ':scheme'        => 'https',
             ':method'        => 'OTHER',
             ':path'          => '/another',
-            'host'           => 'rob.local',
+            ':authority'     => 'rob.local:80',
             'x-custom'       => 'custom',
             'content-length' => '999'
           }
@@ -100,11 +100,11 @@ describe NetHttp2::Request do
 
         it { is_expected.to eq(
           {
-            ':scheme'  => 'http',
-            ':method'  => 'GET',
-            ':path'    => '/path',
-            'host'     => 'rob.local',
-            'x-custom' => 'custom'
+            ':scheme'    => 'http',
+            ':method'    => 'GET',
+            ':path'      => '/path',
+            ':authority' => 'rob.local:80',
+            'x-custom'   => 'custom'
           }
         ) }
       end


### PR DESCRIPTION
According to [RFC7540 8.1.2.3](https://tools.ietf.org/html/rfc7540#section-8.1.2.3), the client [SHOULD](https://tools.ietf.org/html/rfc2119#section-3) use ':authority' request pseudo-header field instead of 'host' request header field.
There are some websites which does not respond to the request that contains 'host' header field. 
If the request contains 'host', Google will close the connection immediately and the response by Twitter will be 404.