### PR TITLE
Proxy support

### DIFF
--- a/lib/net-http2/socket.rb
+++ b/lib/net-http2/socket.rb
@@ -3,15 +3,22 @@ module NetHttp2
   module Socket
 
     def self.create(uri, options)
-      options[:ssl] ? ssl_socket(uri, options) : tcp_socket(uri, options)
+      return ssl_socket(uri, options) if options[:ssl]
+      return proxy_tcp_socket(uri, options) if options[:proxy_addr]
+
+      tcp_socket(uri, options)
     end
 
     def self.ssl_socket(uri, options)
-      tcp = tcp_socket(uri, options)
+      tcp = if options[:proxy_addr]
+        proxy_tcp_socket(uri, options)
+      else
+        tcp_socket(uri, options)
+      end
 
       socket            = OpenSSL::SSL::SSLSocket.new(tcp, options[:ssl_context])
       socket.sync_close = true
-      socket.hostname   = uri.hostname
+      socket.hostname   = options[:proxy_addr] || uri.host
 
       socket.connect
 
@@ -45,6 +52,50 @@ module NetHttp2
       end
 
       socket
+    end
+
+    def self.proxy_tcp_socket(uri, options)
+      proxy_addr = options[:proxy_addr]
+      proxy_port = options[:proxy_port]
+      proxy_user = options[:proxy_user]
+      proxy_pass = options[:proxy_pass]
+
+      proxy_uri = URI.parse("#{proxy_addr}:#{proxy_port}")
+      proxy_socket = tcp_socket(proxy_uri, options)
+
+      # The majority of proxies do not explicitly support HTTP/2 protocol,
+      # while they successfully create a TCP tunnel
+      # which can pass through binary data of HTTP/2 connection.
+      # So we’ll keep HTTP/1.1
+      http_version = '1.1'
+
+      buf = "CONNECT #{uri.host}:#{uri.port} HTTP/#{http_version}\r\n"
+      buf << "Host: #{uri.host}:#{uri.port}\r\n"
+      if proxy_user
+        credential = ["#{proxy_user}:#{proxy_pass}"].pack('m')
+        credential.delete!("\r\n")
+        buf << "Proxy-Authorization: Basic #{credential}\r\n"
+      end
+      buf << "\r\n"
+      proxy_socket.write(buf)
+      validate_proxy_response!(proxy_socket)
+
+      proxy_socket
+    end
+
+    private
+
+    def self.validate_proxy_response!(socket)
+      result = ''
+      loop do
+        line = socket.gets
+        break if !line || line.strip.empty?
+
+        result << line
+      end
+      return if result =~ /HTTP\/\d(?:\.\d)?\s+2\d\d\s/
+
+      raise(StandardError, "Proxy connection failure:\n#{result}")
     end
   end
 end

--- a/spec/http2-client/client_spec.rb
+++ b/spec/http2-client/client_spec.rb
@@ -48,4 +48,38 @@ describe NetHttp2::Client do
       it { is_expected.to eq true }
     end
   end
+
+  describe '#proxy_tcp_socket' do
+    let(:target_location) { 'bigbrother.com' }
+    let(:target_port) { '9999' }
+    let(:uri) { URI.parse("https://#{target_location}:#{target_port}") }
+    let(:options) {
+      {
+        ssl_context: OpenSSL::SSL::SSLContext.new,
+        proxy_addr: 'http://hidemyass.proxy.com',
+        proxy_port: '3213',
+        proxy_user: 'someuser',
+        proxy_pass: 'somepass'
+      }
+    }
+    let(:fake_tcp_socket) { double }
+    let(:fake_ssl_socket) { double(:sync_close= => 'ok', :connect => 'ok') }
+
+    it 'establish connection through proxy with credentials' do
+      expect(OpenSSL::SSL::SSLSocket).to receive(:new) { fake_ssl_socket }
+      expect(NetHttp2::Socket).to receive(:tcp_socket).
+        with(URI.parse("#{options[:proxy_addr]}:#{options[:proxy_port]}"), options).
+        exactly(:once) { fake_tcp_socket }
+      expect(fake_tcp_socket).to receive(:write).with(
+        "CONNECT #{target_location}:#{target_port} HTTP/1.1\r\n"\
+          "Host: #{target_location}:#{target_port}\r\n"\
+          "Proxy-Authorization: Basic c29tZXVzZXI6c29tZXBhc3M=\r\n\r\n"
+      )
+      expect(fake_tcp_socket).to receive(:gets).
+        and_return('HTTP/1.1 200 OK', '')
+      expect(fake_ssl_socket).to receive(:hostname=).with(options[:proxy_addr])
+
+      NetHttp2::Socket.ssl_socket(uri, options)
+    end
+  end
 end


### PR DESCRIPTION
Note #1
Majority of proxies do not explicitly support HTTP/2
protocol, while they successfully create
tcp tunnel, so we keep HTTP/1.1 in a CONNECT request

Note #2
Proxy may return any response code starting with 2
(2xx) as a success response, not just 200.