### PR TITLE
Expose remote connection settings and stream count.

### DIFF
--- a/lib/net-http2/client.rb
+++ b/lib/net-http2/client.rb
@@ -60,6 +60,14 @@ module NetHttp2
       end
     end
 
+    def remote_settings
+      h2.remote_settings
+    end
+
+    def stream_count
+      @streams.length
+    end
+
     private
 
     def init_vars

--- a/spec/http2-client/client_spec.rb
+++ b/spec/http2-client/client_spec.rb
@@ -87,4 +87,24 @@ describe NetHttp2::Client do
     subject { NetHttp2::Client.new("http://localhost") }
     it_behaves_like "a class that implements events subscription & emission"
   end
+
+  describe "#remote_settings" do
+    let(:client) { NetHttp2::Client.new("http://localhost") }
+
+    subject { client.remote_settings}
+    it { is_expected.to have_key :settings_header_table_size }
+    it { is_expected.to have_key :settings_enable_push }
+    it { is_expected.to have_key :settings_max_concurrent_streams }
+    it { is_expected.to have_key :settings_initial_window_size }
+    it { is_expected.to have_key :settings_max_frame_size }
+    it { is_expected.to have_key :settings_max_header_list_size }
+  end
+
+  describe "#stream_count" do
+    let(:client) { NetHttp2::Client.new("http://localhost") }
+
+    subject { client.stream_count}
+    it { is_expected.to eq 0 }
+  end
+
 end


### PR DESCRIPTION
Exposing these is necessary to support ostinelli/apnotic#28.