### PR TITLE
Relax http-2 dependency

### DIFF
--- a/net-http2.gemspec
+++ b/net-http2.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "http-2", "~> 0.9.0"
+  spec.add_dependency "http-2", [">= 0.9.0", "< 0.9.2"]
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/net-http2.gemspec
+++ b/net-http2.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "http-2", "0.9.0"
+  spec.add_dependency "http-2", "~> 0.9.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
That way we're a bit more optimistic about changes and also don't fix people using that gem for other purposes. What do you think?

https://github.com/igrigorik/http-2/compare/v0.9.0...v0.9.1