### PR TITLE
Deduce address family from Socket.getaddrinfo

### DIFF
--- a/lib/net-http2/socket.rb
+++ b/lib/net-http2/socket.rb
@@ -26,8 +26,9 @@ module NetHttp2
     end
 
     def self.tcp_socket(uri, options)
-      family   = ::Socket::AF_INET
-      address  = ::Socket.getaddrinfo(uri.host, nil, family).first[3]
+      addrinfo = ::Socket.getaddrinfo(uri.host, nil, nil)
+      address  = addrinfo.first[3]
+      family   = addrinfo.first[4]
       sockaddr = ::Socket.pack_sockaddr_in(uri.port, address)
 
       socket = ::Socket.new(family, ::Socket::SOCK_STREAM, 0)


### PR DESCRIPTION
This removes the dependence on AF_INET and allows IPv6-only hosts to be connected to.

Closes #32.