### PR TITLE
Get back the reason of a socket closed error

### DIFF
--- a/lib/net-http2/client.rb
+++ b/lib/net-http2/client.rb
@@ -112,7 +112,7 @@ module NetHttp2
           rescue EOFError
             # socket closed
             init_vars
-            callback_or_raise SocketError.new('Socket was remotely closed')
+            callback_or_raise SocketError.new(@goawayReason || "Socket was remotely closed")
 
           rescue Exception => e
             # error on socket
@@ -172,6 +172,12 @@ module NetHttp2
             @socket.flush
 
             @first_data_sent = true
+          end
+        end
+        h2.on(:frame_received) do |frame|
+          if frame[:type] == :goaway
+            payload = JSON.parse(frame[:payload])
+            @goawayReason = payload["reason"]
           end
         end
       end


### PR DESCRIPTION
Hi @ostinelli , thanks for all your great work!

I've had the "SocketError: Socket was remotely closed" various times trying the Apnotic library.
I looked a way to get more informations about the reason of a connection shutdown by the Apple server, and looking in the Apple doc I've found this interesting section: https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html#//apple_ref/doc/uid/TP40008194-CH11-SW9

> If APNs decides to terminate an established HTTP/2 connection, it sends a GOAWAY frame. The GOAWAY frame includes JSON data in its payload with a reason key, whose value indicates the reason for the connection termination. Normal request failures do not result in termination of a connection.

So the socket error should come with a GOAWAY frame with the reason of the issue: https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html#//apple_ref/doc/uid/TP40008194-CH11-SW17

I'm not a Ruby developer so I could be wrong but it seems we can't get that GOAWAY frame in the Apnotic library.
For that reason I've tried to modify the net-http2 library in order to get the reason from the GOAWAY frame.

I'm parsing the GOAWAY frame directly in the net-http2 lib and it doesn the work for me but I guess a better solution would be sending the content of the GOAWAY frame along with the SocketError, parsing the GOAWAY content inside the Apnotic library as its formatting is specific for Apple.

As I said I'm not a Ruby dev so happy to hear your comments and improvements!
Thanks
