### PR TITLE
Support running with --enable=frozen-string-literal

### DIFF
--- a/lib/net-http2/socket.rb
+++ b/lib/net-http2/socket.rb
@@ -70,7 +70,8 @@ module NetHttp2
       # So we’ll keep HTTP/1.1
       http_version = '1.1'
 
-      buf = "CONNECT #{uri.host}:#{uri.port} HTTP/#{http_version}\r\n"
+      buf = String.new
+      buf << "CONNECT #{uri.host}:#{uri.port} HTTP/#{http_version}\r\n"
       buf << "Host: #{uri.host}:#{uri.port}\r\n"
       if proxy_user
         credential = ["#{proxy_user}:#{proxy_pass}"].pack('m')
@@ -87,7 +88,7 @@ module NetHttp2
     private
 
     def self.validate_proxy_response!(socket)
-      result = ''
+      result = String.new
       loop do
         line = socket.gets
         break if !line || line.strip.empty?

--- a/lib/net-http2/stream.rb
+++ b/lib/net-http2/stream.rb
@@ -5,7 +5,7 @@ module NetHttp2
     def initialize(options={})
       @h2_stream = options[:h2_stream]
       @headers   = {}
-      @data      = ''
+      @data      = String.new
       @request   = nil
       @async     = false
       @completed = false

--- a/spec/api/errors_spec.rb
+++ b/spec/api/errors_spec.rb
@@ -1,3 +1,4 @@
+# frozen-string-literal: false
 require 'spec_helper'
 
 describe "Errors" do

--- a/spec/api/sending_async_requests_spec.rb
+++ b/spec/api/sending_async_requests_spec.rb
@@ -1,3 +1,4 @@
+# frozen-string-literal: false
 require 'spec_helper'
 
 describe "Sending async requests" do

--- a/spec/support/dummy_server.rb
+++ b/spec/support/dummy_server.rb
@@ -1,3 +1,4 @@
+# frozen-string-literal: false
 module NetHttp2
 
   module Dummy


### PR DESCRIPTION
In apps that run with `--enable=frozen-string-literal` we can get a `FrozenError`.

Using `String.new` instead of `''` fixes that without breaking it for anyone else.

When running the specs with frozen strings (`RUBYOPT="--enable=frozen-string-literal" rake`), there were three test files that also generate errors. I added the magic comment: `# frozen-string-literal: false`
to those to work both ways.

I have a related PR on `http-2` to get all the specs passing: https://github.com/igrigorik/http-2/pull/161