### PR TITLE
`http-2` dependency bumped, fixes #53

### DIFF
--- a/lib/net-http2/version.rb
+++ b/lib/net-http2/version.rb
@@ -1,3 +1,3 @@
 module NetHttp2
-  VERSION = '0.18.5'.freeze
+  VERSION = '0.19.0'.freeze
 end

--- a/net-http2.gemspec
+++ b/net-http2.gemspec
@@ -11,15 +11,14 @@ Gem::Specification.new do |spec|
   spec.email                 = ["roberto@ostinelli.net"]
   spec.summary               = %q{NetHttp2 is an HTTP2 client for Ruby.}
   spec.homepage              = "http://github.com/ostinelli/net-http2"
-  spec.required_ruby_version = '>=2.1.0'
-
+  spec.required_ruby_version = '>=2.7.0'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "http-2", "~> 0.11"
+  spec.add_dependency "http-2", ">= 1.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", ">= 12.3.3"


### PR DESCRIPTION
`http-2` has gone 1.x, [as stated in their CHANGELOG](https://github.com/igrigorik/http-2/blob/main/CHANGELOG.md) the only potentially breaking change is that they now require ruby 2.7 or above.

All specs passed.

I've reflected that constraint in this change which I can't imagine would be a big issue, and for that reason I bumped your gem version to 0.19.

Please consider merging this to resolve #53.